### PR TITLE
logpipe fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
     restart: ${SF_RESTART:-on-failure}
     cgroup_parent: sf.slice
     volumes:
-      - "${SF_BASEDIR:-.}/config/etc/logpipe/config.yaml:/app/config.yaml:ro"    
+      - "${SF_BASEDIR:-.}/config/etc/logpipe/:/app/config/:ro"    
       - "/dev/shm/sf/run/logpipe/:/app/sock/:rw"
       
   sf-portd:

--- a/tools/logpipe/main.go
+++ b/tools/logpipe/main.go
@@ -21,7 +21,7 @@ type LogPipe struct {
 func main() {
 	lp := LogPipe{}
 
-	fbytes, ferr := os.ReadFile("config.yaml")
+	fbytes, ferr := os.ReadFile("./config/config.yaml")
 	if ferr == nil {
 		err := yaml.Unmarshal(fbytes, &lp)
 		if err != nil {

--- a/tools/logpipe/main.go
+++ b/tools/logpipe/main.go
@@ -47,6 +47,8 @@ func listenOnSocket(socketFile string) {
 		return
 	}
 
+	os.Chmod(socketFile, 0777)
+
 	for {
 		conn, err := listener.Accept()
 		if err != nil {


### PR DESCRIPTION
1)  modified location on config.yaml
issue: changes made to config.yaml (in host) not propagated to container
Reason: direct config file mapping(with ro) in docker-compose.
Fix: map a directory with config file inside it.

2) fixed permission for socket created by logpipe
issue/reason: segfaultsh doesnt not run as root, and cannot write to socket which is owned by root
Fix: chmod 777 , :-)